### PR TITLE
GSI-LCG2: remove trailing slash from the endpoint URI

### DIFF
--- a/sites/GSI-LCG2.yaml
+++ b/sites/GSI-LCG2.yaml
@@ -1,4 +1,4 @@
-endpoint: https://egiosc.gsi.de:5000/v3/
+endpoint: https://egiosc.gsi.de:5000/v3
 gocdb: GSI-LCG2
 vos:
 - name: dteam


### PR DESCRIPTION
Turns out the InfoProvider probe on ARGO-Mon2 requires this to be *exactly* as in GOCDB.
