### PR TITLE
update from fedcloudlient

### DIFF
--- a/sites/BIFI.yaml
+++ b/sites/BIFI.yaml
@@ -1,4 +1,5 @@
 endpoint: https://colossus.cesar.unizar.es:5000/v3
+filename: BIFI.yaml
 gocdb: BIFI
 vos:
 - auth:
@@ -10,3 +11,12 @@ vos:
 - auth:
     project_id: 34671c4356fd4c66835f30650c20612e
   name: gosafe.eng.it
+- auth:
+    project_id: 621b1977bb384beab1519713c7e695f0
+  name: o3as.data.kit.edu
+- auth:
+    project_id: fce23a2c4eca447a9d5b9c2bdab55e26
+  name: worsica.eosc.eu
+- auth:
+    project_id: bb8a629f3e644b69befbf17130c1dee3
+  name: lagoproject.net

--- a/sites/BIFI.yaml
+++ b/sites/BIFI.yaml
@@ -1,5 +1,4 @@
 endpoint: https://colossus.cesar.unizar.es:5000/v3
-filename: BIFI.yaml
 gocdb: BIFI
 vos:
 - auth:

--- a/sites/CESNET-MCC.yaml
+++ b/sites/CESNET-MCC.yaml
@@ -1,5 +1,4 @@
 endpoint: https://identity.cloud.muni.cz/v3
-filename: CESNET-MCC.yaml
 gocdb: CESNET-MCC
 vos:
 - auth:

--- a/sites/CESNET-MCC.yaml
+++ b/sites/CESNET-MCC.yaml
@@ -1,4 +1,5 @@
 endpoint: https://identity.cloud.muni.cz/v3
+filename: CESNET-MCC.yaml
 gocdb: CESNET-MCC
 vos:
 - auth:
@@ -67,3 +68,9 @@ vos:
 - auth:
     project_id: 89140661b6be4ef281ab7a67d4c83e0c
   name: vo.europlanet-vespa.eu
+- auth:
+    project_id: 10e31299a9b548fdbe36e4dbe571168e
+  name: umsa.cerit-sc.cz
+- auth:
+    project_id: d0ebf0fad0a04be19f93fdf794469544
+  name: cryoem.instruct-eric.eu

--- a/sites/IFCA-LCG2.yaml
+++ b/sites/IFCA-LCG2.yaml
@@ -44,20 +44,8 @@ vos:
     project_id: 7bb9c2694f9040c68cd72cb994f5ce89
   name: worsica.eosc.eu
 - auth:
-    project_id: 352db003073549749351fad26cd55074
-  name: VO:o3as.data.kit.edu
-- auth:
-    project_id: 3b9754ad8c6046b4aec43ec21abe7d8c
-  name: VO:eosc-synergy.eu
-- auth:
-    project_id: 7bb9c2694f9040c68cd72cb994f5ce89
-  name: VO:worsica.vo.incd.pt
-- auth:
     project_id: c7db08b907ef4f0fae73bdd6587bc79e
-  name: VO:cryoem.instruct-eric.eu
-- auth:
-    project_id: e14972ead3154810a5941e511afc208c
-  name: VO:covid19.eosc-synergy.eu
+  name: cryoem.instruct-eric.eu
 - auth:
     project_id: 77c86367335f4e9cb1e9ccab72d24f0a
-  name: VO:lagoproject.net
+  name: lagoproject.net

--- a/sites/IFCA-LCG2.yaml
+++ b/sites/IFCA-LCG2.yaml
@@ -1,4 +1,5 @@
 endpoint: https://api.cloud.ifca.es:5000/v3/
+filename: IFCA-LCG2.yaml
 gocdb: IFCA-LCG2
 vos:
 - auth:
@@ -43,3 +44,21 @@ vos:
 - auth:
     project_id: 7bb9c2694f9040c68cd72cb994f5ce89
   name: worsica.eosc.eu
+- auth:
+    project_id: 352db003073549749351fad26cd55074
+  name: VO:o3as.data.kit.edu
+- auth:
+    project_id: 3b9754ad8c6046b4aec43ec21abe7d8c
+  name: VO:eosc-synergy.eu
+- auth:
+    project_id: 7bb9c2694f9040c68cd72cb994f5ce89
+  name: VO:worsica.vo.incd.pt
+- auth:
+    project_id: c7db08b907ef4f0fae73bdd6587bc79e
+  name: VO:cryoem.instruct-eric.eu
+- auth:
+    project_id: e14972ead3154810a5941e511afc208c
+  name: VO:covid19.eosc-synergy.eu
+- auth:
+    project_id: 77c86367335f4e9cb1e9ccab72d24f0a
+  name: VO:lagoproject.net

--- a/sites/IFCA-LCG2.yaml
+++ b/sites/IFCA-LCG2.yaml
@@ -1,5 +1,4 @@
 endpoint: https://api.cloud.ifca.es:5000/v3/
-filename: IFCA-LCG2.yaml
 gocdb: IFCA-LCG2
 vos:
 - auth:

--- a/sites/IISAS-FedCloud-cloud.yaml
+++ b/sites/IISAS-FedCloud-cloud.yaml
@@ -1,5 +1,4 @@
 endpoint: https://cloud.ui.savba.sk:5000/v3/
-filename: IISAS-FedCloud-cloud.yaml
 gocdb: IISAS-FedCloud
 vos:
 - auth:

--- a/sites/IISAS-FedCloud-cloud.yaml
+++ b/sites/IISAS-FedCloud-cloud.yaml
@@ -1,4 +1,5 @@
 endpoint: https://cloud.ui.savba.sk:5000/v3/
+filename: IISAS-FedCloud-cloud.yaml
 gocdb: IISAS-FedCloud
 vos:
 - auth:
@@ -16,4 +17,21 @@ vos:
 - auth:
     project_id: 071a2c4b52494bccbc3606d59d0e6951
   name: mteam.data.kit.edu
-  
+- auth:
+    project_id: a87268866a534fe38c49f5ec154d0223
+  name: covid19.eosc-synergy.eu
+- auth:
+    project_id: d09a0c28397f4b41ad4bd62e7d63b51e
+  name: eosc-synergy.eu
+- auth:
+    project_id: af0a1e8165b94365903088e00e34b063
+  name: cryoem.instruct-eric.eu
+- auth:
+    project_id: a87268866a534fe38c49f5ec154d0223
+  name: covid19.eosc-synergy.eu
+- auth:
+    project_id: d09a0c28397f4b41ad4bd62e7d63b51e
+  name: eosc-synergy.eu
+- auth:
+    project_id: af0a1e8165b94365903088e00e34b063
+  name: cryoem.instruct-eric.eu

--- a/sites/IISAS-FedCloud-cloud.yaml
+++ b/sites/IISAS-FedCloud-cloud.yaml
@@ -25,12 +25,3 @@ vos:
 - auth:
     project_id: af0a1e8165b94365903088e00e34b063
   name: cryoem.instruct-eric.eu
-- auth:
-    project_id: a87268866a534fe38c49f5ec154d0223
-  name: covid19.eosc-synergy.eu
-- auth:
-    project_id: d09a0c28397f4b41ad4bd62e7d63b51e
-  name: eosc-synergy.eu
-- auth:
-    project_id: af0a1e8165b94365903088e00e34b063
-  name: cryoem.instruct-eric.eu

--- a/sites/IISAS-GPUCloud.yaml
+++ b/sites/IISAS-GPUCloud.yaml
@@ -1,5 +1,4 @@
 endpoint: https://keystone3.ui.savba.sk:5000/v3/
-filename: IISAS-GPUCloud.yaml
 gocdb: IISAS-GPUCloud
 vos:
 - auth:

--- a/sites/IISAS-GPUCloud.yaml
+++ b/sites/IISAS-GPUCloud.yaml
@@ -1,4 +1,5 @@
 endpoint: https://keystone3.ui.savba.sk:5000/v3/
+filename: IISAS-GPUCloud.yaml
 gocdb: IISAS-GPUCloud
 vos:
 - auth:
@@ -13,3 +14,9 @@ vos:
 - auth:
     project_id: 627905392d4d453cbd85e8d56b2367b0
   name: training.egi.eu
+- auth:
+    project_id: 6c8c9a38f957420b86e0cdeb58def770
+  name: mswss.ui.savba.sk
+- auth:
+    project_id: f82b19069f644c0dafcad4b7f6a4dac0
+  name: cryoem.instruct-eric.eu

--- a/sites/NCG-INGRID-PT.yaml
+++ b/sites/NCG-INGRID-PT.yaml
@@ -23,11 +23,5 @@ vos:
     project_id: 05e52356addc44e18ef2bd14f2e2f67d
   name: covid-synergy
 - auth:
-    project_id: a53ca78c534046e5b13f4537ae698411
-  name: worsica
-- auth:
-    project_id: ddf0c468c8af4e0bbb9808bfc0288381
-  name: eosc-synergy
-- auth:
     project_id: 14e8f964db4c4a8ea286b0886ab51e7c
-  name: lago
+  name: lagoproject.net

--- a/sites/NCG-INGRID-PT.yaml
+++ b/sites/NCG-INGRID-PT.yaml
@@ -20,8 +20,5 @@ vos:
     project_id: a53ca78c534046e5b13f4537ae698411
   name: worsica.vo.incd.pt
 - auth:
-    project_id: 05e52356addc44e18ef2bd14f2e2f67d
-  name: covid-synergy
-- auth:
     project_id: 14e8f964db4c4a8ea286b0886ab51e7c
   name: lagoproject.net

--- a/sites/NCG-INGRID-PT.yaml
+++ b/sites/NCG-INGRID-PT.yaml
@@ -1,4 +1,5 @@
 endpoint: https://stratus.ncg.ingrid.pt:5000/v3
+filename: NCG-INGRID-PT.yaml
 gocdb: NCG-INGRID-PT
 vos:
 - auth:
@@ -19,3 +20,15 @@ vos:
 - auth:
     project_id: a53ca78c534046e5b13f4537ae698411
   name: worsica.vo.incd.pt
+- auth:
+    project_id: 05e52356addc44e18ef2bd14f2e2f67d
+  name: covid-synergy
+- auth:
+    project_id: a53ca78c534046e5b13f4537ae698411
+  name: worsica
+- auth:
+    project_id: ddf0c468c8af4e0bbb9808bfc0288381
+  name: eosc-synergy
+- auth:
+    project_id: 14e8f964db4c4a8ea286b0886ab51e7c
+  name: lago

--- a/sites/NCG-INGRID-PT.yaml
+++ b/sites/NCG-INGRID-PT.yaml
@@ -1,5 +1,4 @@
 endpoint: https://stratus.ncg.ingrid.pt:5000/v3
-filename: NCG-INGRID-PT.yaml
 gocdb: NCG-INGRID-PT
 vos:
 - auth:


### PR DESCRIPTION
I wrote a script (https://github.com/EOSC-synergy/sla-monitor/blob/master/update-vo-operations.py) that uses
the output of `fedcloudclient.endpoint.get_projects_from_sites_dict` to update the content of this repository's sites/ folder.

This needs VO membership for the VO to be updated, so adding is safe, removing only possible for VOs where one is sure to be a member of. Therefore I'm currently only adding sites.

Since I expect synergy VOs to be a bit more dynamic, I've written this script.  We see three sites supporting a given VO only for two weeks of may.