### PR TITLE
GSI-LCG2: add auth project for vo.access.egi.eu

### DIFF
--- a/sites/GSI-LCG2.yaml
+++ b/sites/GSI-LCG2.yaml
@@ -10,3 +10,6 @@ vos:
 - name: ops
   auth:
     project_id: c585e9ae796649f2be13d113a43749aa
+- name: vo.access.egi.eu
+  auth:
+    project_id: 1392719e6e4c4bf7ba0fce8c0acbbd22


### PR DESCRIPTION
The title says it all. Everything on our end has already been configured for this VO and the OLA should be ready shortly.