### PR TITLE
Add missing VO to IN2P3-IRES site

### DIFF
--- a/sites/IN2P3-IRES.yaml
+++ b/sites/IN2P3-IRES.yaml
@@ -2,14 +2,47 @@ endpoint: https://sbgcloud.in2p3.fr:5000/v3
 gocdb: IN2P3-IRES
 vos:
 - auth:
+    project_id: e5258170eee8429da316e6a710f6d185
+  name: belle
+- auth:
+    project_id: d579ada647314c91989daa63399fe2fa
+  name: benchmark.terradue.com 
+- auth:
+    project_id: bf15d4331f3d4c3997e17c0740930e8c
+  name: bioisi
+- auth:
+    project_id: 3a43bcf92f954d79ac1dcf07c5833e49
+  name: biomed
+- auth:
+    project_id: 187caf7c40a2463390b59b3970f2048d
+  name: cms
+- auth:
+    project_id: 2490c27604904357b9e50c5e77aaeedf
+  name: dteam
+- auth:
     project_id: a5eb30bba2c2497b90645fb199e34b39
   name: fedcloud.egi.eu
 - auth:
     project_id: 8bea7dbd202f4cbcafb7e00334f320f2
   name: med.semmelweis-univ.hu
 - auth:
+    project_id: 929ff81c495b4cafb02fa1b8eef032c8
+  name: ops
+- auth:
     project_id: 7a91022b9ae74ed9ac1a574972a79499
   name: vo.access.egi.eu
 - auth:
+    project_id: 2dfd063612f14a84989496e1a8ac080e
+  name: vo.elixir-europe.org
+- auth:
     project_id: 3232754379c3469c9e8dbe8f403a8835
   name: vo.emphasisproject.eu
+- auth:
+    project_id: c8005e7c85ca4929bde70882ae1ec137
+  name: vo.europlanet-vespa.eu
+- auth:
+    project_id: b822cf1f1c24427599ccb6bbe6266ae7
+  name: vo.nbis.se
+- auth:
+    project_id: bc4fed7e87514dd884924c77cad714bc
+  name: vo.operas-eu.org


### PR DESCRIPTION
# Summary

All VOs managed by EGI have been added to the IN2P3-IRES site.