### PR TITLE
Move to mytoken for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
         CHECKIN_CLIENT_SECRET: ${{ secrets.CHECKIN_CLIENT_SECRET }}
         CHECKIN_REFRESH_TOKEN: ${{ secrets.CHECKIN_REFRESH_TOKEN }}
       run: |
+        set -x
         PATH="$PWD:$PATH"
         cd deploy
         BACKEND_SITE="$(yq -r .clouds.backend.site clouds.yaml)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,24 +25,21 @@ jobs:
         pip install yq fedcloudclient
         curl -L https://github.com/oidc-mytoken/client/releases/download/v0.3.0/mytoken_0.3.0_Linux_x86_64.tar.gz \
           | tar -xzf -
+        mkdir ~/.mytoken
+        curl https://raw.githubusercontent.com/oidc-mytoken/client/master/config/example-config.yaml > ~/.mytoken/config.yaml
     - name: Configure providers access
       env:
         MYTOKEN: ${{ secrets.MYTOKEN }}
       run: |
-        set -x
-        mkdir ~/.mytoken
-        curl https://raw.githubusercontent.com/oidc-mytoken/client/master/config/example-config.yaml > ~/.mytoken/config.yaml
-        OIDC_TOKEN=$(./mytoken AT --MT-env MYTOKEN)
-        echo "::add-mask::$OIDC_TOKEN"
         PATH="$PWD:$PATH"
+        OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+        echo "::add-mask::$OIDC_TOKEN"
         cd deploy
         BACKEND_SITE="$(yq -r .clouds.backend.site clouds.yaml)"
         BACKEND_VO="$(yq -r .clouds.backend.vo clouds.yaml)"
         EGI_SITE="$(yq -r .clouds.deploy.site clouds.yaml)"
         DEPLOY_VO="$(yq -r .clouds.deploy.vo clouds.yaml)"
         echo "EGI_SITE=$EGI_SITE" >> "$GITHUB_ENV"
-        fedcloud site show --site NCG-INGRID-PT
-        fedcloud site show-project-id --vo cloud.egi.eu --site NCG-INGRID-PT
         BACKEND_OS_TOKEN="$(fedcloud openstack token issue --oidc-access-token "$OIDC_TOKEN" \
                                                            --site "$BACKEND_SITE" --vo "$BACKEND_VO" -j | jq -r '.[0].Result.id')"
         echo "::add-mask::$BACKEND_OS_TOKEN"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         set -x
         mkdir ~/.mytoken
         curl https://raw.githubusercontent.com/oidc-mytoken/client/master/config/example-config.yaml > ~/.mytoken/config.yaml
-        OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+        OIDC_TOKEN=$(./mytoken AT --MT-env MYTOKEN)
         echo "::add-mask::$OIDC_TOKEN"
         PATH="$PWD:$PATH"
         cd deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - "deploy/**"
+  #  paths:
+  #    - "deploy/**"
 
 jobs:
   terraform:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,11 +41,11 @@ jobs:
         EGI_SITE="$(yq -r .clouds.deploy.site clouds.yaml)"
         DEPLOY_VO="$(yq -r .clouds.deploy.vo clouds.yaml)"
         echo "EGI_SITE=$EGI_SITE" >> "$GITHUB_ENV"
-        BACKEND_OS_TOKEN="$(fedcloud openstack token issue --oidc-refresh-token "$OIDC_TOKEN" \
+        BACKEND_OS_TOKEN="$(fedcloud openstack token issue --oidc-access-token "$OIDC_TOKEN" \
                                                            --site "$BACKEND_SITE" --vo "$BACKEND_VO" -j | jq -r '.[0].Result.id')"
         echo "::add-mask::$BACKEND_OS_TOKEN"
         sed -i -e "s/backend_secret/$BACKEND_OS_TOKEN/" clouds.yaml
-        DEPLOY_OS_TOKEN="$(fedcloud openstack token issue --oidc-refresh-token "$OIDC_TOKEN" \
+        DEPLOY_OS_TOKEN="$(fedcloud openstack token issue --oidc-access-token "$OIDC_TOKEN" \
                                                            --site "$EGI_SITE" --vo "$DEPLOY_VO" -j | jq -r '.[0].Result.id')"
         echo "::add-mask::$DEPLOY_OS_TOKEN"
         sed -i -e "s/deploy_secret/$DEPLOY_OS_TOKEN/" clouds.yaml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > jq
         chmod +x jq
-        pip install yq fedcloudclient
+        pip install yq git+https://github.com/tdviet/fedcloudclient.git
         curl -L https://github.com/oidc-mytoken/client/releases/download/v0.3.0/mytoken_0.3.0_Linux_x86_64.tar.gz \
           | tar -xzf -
         mkdir ~/.mytoken

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
   pull_request:
-  #  paths:
-  #    - "deploy/**"
+    paths:
+      - "deploy/**"
 
 jobs:
   terraform:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,18 +18,22 @@ jobs:
       uses: actions/checkout@v2
     - name: Setup python
       uses: actions/setup-python@v2
-    - name: Install python packages
+    - name: Install environment
       run: |
         curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > jq
         chmod +x jq
         pip install yq fedcloudclient
+        curl -L https://github.com/oidc-mytoken/client/releases/download/v0.3.0/mytoken_0.3.0_Linux_x86_64.tar.gz \
+          | tar -xzf -
     - name: Configure providers access
       env:
-        CHECKIN_CLIENT_ID: ${{ secrets.CHECKIN_CLIENT_ID }}
-        CHECKIN_CLIENT_SECRET: ${{ secrets.CHECKIN_CLIENT_SECRET }}
-        CHECKIN_REFRESH_TOKEN: ${{ secrets.CHECKIN_REFRESH_TOKEN }}
+        MYTOKEN: ${{ secrets.MYTOKEN }}
       run: |
         set -x
+        mkdir ~/.mytoken
+        curl https://raw.githubusercontent.com/oidc-mytoken/client/master/config/example-config.yaml > ~/.mytoken/config.yaml
+        OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+        echo "::add-mask::$OIDC_TOKEN"
         PATH="$PWD:$PATH"
         cd deploy
         BACKEND_SITE="$(yq -r .clouds.backend.site clouds.yaml)"
@@ -37,15 +41,11 @@ jobs:
         EGI_SITE="$(yq -r .clouds.deploy.site clouds.yaml)"
         DEPLOY_VO="$(yq -r .clouds.deploy.vo clouds.yaml)"
         echo "EGI_SITE=$EGI_SITE" >> "$GITHUB_ENV"
-        BACKEND_OS_TOKEN="$(fedcloud openstack token issue --oidc-refresh-token "$CHECKIN_REFRESH_TOKEN" \
-                                                           --oidc-client-id "$CHECKIN_CLIENT_ID" \
-                                                           --oidc-client-secret "$CHECKIN_CLIENT_SECRET" \
+        BACKEND_OS_TOKEN="$(fedcloud openstack token issue --oidc-refresh-token "$OIDC_TOKEN" \
                                                            --site "$BACKEND_SITE" --vo "$BACKEND_VO" -j | jq -r '.[0].Result.id')"
         echo "::add-mask::$BACKEND_OS_TOKEN"
         sed -i -e "s/backend_secret/$BACKEND_OS_TOKEN/" clouds.yaml
-        DEPLOY_OS_TOKEN="$(fedcloud openstack token issue --oidc-refresh-token "$CHECKIN_REFRESH_TOKEN" \
-                                                           --oidc-client-id "$CHECKIN_CLIENT_ID" \
-                                                           --oidc-client-secret "$CHECKIN_CLIENT_SECRET" \
+        DEPLOY_OS_TOKEN="$(fedcloud openstack token issue --oidc-refresh-token "$OIDC_TOKEN" \
                                                            --site "$EGI_SITE" --vo "$DEPLOY_VO" -j | jq -r '.[0].Result.id')"
         echo "::add-mask::$DEPLOY_OS_TOKEN"
         sed -i -e "s/deploy_secret/$DEPLOY_OS_TOKEN/" clouds.yaml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
         EGI_SITE="$(yq -r .clouds.deploy.site clouds.yaml)"
         DEPLOY_VO="$(yq -r .clouds.deploy.vo clouds.yaml)"
         echo "EGI_SITE=$EGI_SITE" >> "$GITHUB_ENV"
+        fedcloud site show --site NCG-INGRID-PT
+        fedcloud site show-project-id --vo cloud.egi.eu --site NCG-INGRID-PT
         BACKEND_OS_TOKEN="$(fedcloud openstack token issue --oidc-access-token "$OIDC_TOKEN" \
                                                            --site "$BACKEND_SITE" --vo "$BACKEND_VO" -j | jq -r '.[0].Result.id')"
         echo "::add-mask::$BACKEND_OS_TOKEN"


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Moving to an alternative way of handling auth for deployment:
1. Use of oidc clientid/refresh token  support will be soon removed from fedcloudclient
2. fedcloudclient does not support the newer client https://aai.egi.eu/fedcloud2 
3. mytoken seems to work and reasonably secure

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
