### PR TITLE
Gzip messages before base64 encoding

### DIFF
--- a/.github/linters/.dockerfilelintrc
+++ b/.github/linters/.dockerfilelintrc
@@ -1,3 +1,0 @@
-rules:
-  # disabled as otherwise CA installation breaks
-  apt-get_recommends: off

--- a/cloud-info/ams-wrapper.sh
+++ b/cloud-info/ams-wrapper.sh
@@ -35,7 +35,7 @@ cloud-info-provider-service --yaml-file "$CLOUD_INFO_CONFIG" \
 ARGO_URL="https://$AMS_HOST/v1/projects/$AMS_PROJECT/topics/$AMS_TOPIC:publish?key=$AMS_TOKEN"
 
 printf '{"messages":[{"attributes":{},"data":"' > ams-payload
-grep -v "UNKNOWN" cloud-info.out | grep -v "^#" | base64 -w 0 >> ams-payload
+grep -v "UNKNOWN" cloud-info.out | grep -v "^#" | gzip | base64 -w 0 >> ams-payload
 printf '"}]}' >> ams-payload
 
 curl -X POST "$ARGO_URL" -H "content-type: application/json" -d @ams-payload


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Reduces the message payload by gzipping the cloud-info-provider output before encoding it and sending to AMS

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** #144
