### PR TITLE
Add a new VM for Keycloak credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,11 @@ jobs:
     - name: Configure providers access
       env:
         MYTOKEN: ${{ secrets.MYTOKEN }}
+        REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
       run: |
-        PATH="$PWD:$PATH"
-        OIDC_TOKEN=$(mytoken AT --MT-env MYTOKEN)
+        OIDC_TOKEN=$(curl -X POST "https://aai.egi.eu/oidc/token" \
+                          -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN&client_id=token-portal&scope=openid%20email%20profile%20voperson_id%20eduperson_entitlement" \
+                        | jq -r ".access_token")
         echo "::add-mask::$OIDC_TOKEN"
         cd deploy
         BACKEND_SITE="$(yq -r .clouds.backend.site clouds.yaml)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,15 +74,20 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         ANSIBLE_SECRETS: ${{ secrets.ANSIBLE_SECRETS }}
+        ANSIBLE_SECRETS_KEYCLOAK: ${{ secrets.ANSIBLE_SECRETS_KEYCLOAK }}
       run: |
         cd deploy
         sed -i -e "s/%TOKEN%/${{ steps.generate-token.outputs.token }}/" cloud-init.yaml
         sed -i -e "s/%REF%/${{ github.sha }}/" cloud-init.yaml
         sed -i -e "s/%SHORT_REF%/$(git rev-parse --short HEAD)/" cloud-init.yaml
         sed -i -e "s#%SLACK_WEBHOOK_URL%#$SLACK_WEBHOOK_URL#" cloud-init.yaml
+        cp cloud-init.yaml cloud-init-keycloak.yaml
         ANSIBLE_ENCODED_SECRETS="$(echo "$ANSIBLE_SECRETS" | base64 -w 0)"
         echo "::add-mask::$ANSIBLE_ENCODED_SECRETS"
         sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS/" cloud-init.yaml
+        ANSIBLE_ENCODED_SECRETS_KEYCLOAK="$(echo "$ANSIBLE_SECRETS_KEYCLOAK" | base64 -w 0)"
+        echo "::add-mask::$ANSIBLE_ENCODED_SECRETS_KEYCLOAK"
+        sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS_KEYCLOAK/" cloud-init-keycloak.yaml
     - name: terraform plan
       id: plan
       if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
         sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS/" cloud-init.yaml
         echo "$ANSIBLE_SECRETS_KEYCLOAK" > secrets.yaml
         echo "checkin_token_endpoint: https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token" >> secrets.yaml
-        ANSIBLE_ENCODED_SECRETS_KEYCLOAK="$(cat secrets.yaml | base64 -w 0)"
+        ANSIBLE_ENCODED_SECRETS_KEYCLOAK="$(base64 -w 0 < secrets.yaml)"
         echo "::add-mask::$ANSIBLE_ENCODED_SECRETS_KEYCLOAK"
         sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS_KEYCLOAK/" cloud-init-keycloak.yaml
     - name: terraform plan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,9 @@ jobs:
         ANSIBLE_ENCODED_SECRETS="$(echo "$ANSIBLE_SECRETS" | base64 -w 0)"
         echo "::add-mask::$ANSIBLE_ENCODED_SECRETS"
         sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS/" cloud-init.yaml
-        ANSIBLE_ENCODED_SECRETS_KEYCLOAK="$(echo "$ANSIBLE_SECRETS_KEYCLOAK" | base64 -w 0)"
+        echo "$ANSIBLE_SECRETS_KEYCLOAK" > secrets.yaml
+        echo "checkin_token_endpoint: https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token" >> secrets.yaml
+        ANSIBLE_ENCODED_SECRETS_KEYCLOAK="$(cat secrets.yaml | base64 -w 0)"
         echo "::add-mask::$ANSIBLE_ENCODED_SECRETS_KEYCLOAK"
         sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS_KEYCLOAK/" cloud-init-keycloak.yaml
     - name: terraform plan

--- a/cloud-info/Dockerfile
+++ b/cloud-info/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-ARG CLOUD_INFO_VERSION=a1aa462fc5d1ccbad2f7c0e68336003d761ec63e
+ARG CLOUD_INFO_VERSION=f6f6a2e265cc9608d791f31a8ef2903302ca33f6
 
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir \

--- a/cloud-info/ams-wrapper.sh
+++ b/cloud-info/ams-wrapper.sh
@@ -49,6 +49,10 @@ else
                                 --format glue21 > cloud-info.out
 fi
 
+# Fail if there are no shares
+grep -q GLUE2ShareID cloud-info.out \
+    || (echo "No share information available, aborting!"; false)
+
 # Publishing on our own as message is too large for some providers
 ARGO_URL="https://$AMS_HOST/v1/projects/$AMS_PROJECT/topics/$AMS_TOPIC:publish?key=$AMS_TOKEN"
 

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -8,3 +8,14 @@ resource "openstack_compute_instance_v2" "cloud-info" {
     uuid = var.net_id
   }
 }
+
+resource "openstack_compute_instance_v2" "cloud-info-keycloak" {
+  name            = "cloud-info-keycloak"
+  image_id        = var.image_id
+  flavor_id       = var.flavor_id
+  security_groups = ["default"]
+  user_data       = file("cloud-init-keycloak.yaml")
+  network {
+    uuid = var.net_id
+  }
+}


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
While Check-in moves from MitreID to Keycloak we will have 2 VMs running the cloud-info-provider. One with the service account with MitreID Check-in tokens, the other with Keycloak tokens. 
When the cloud-info-provider fails to authenticate will not send messages to AMS, so as sites transition from one system to another flow of messages should be kept. 

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
