### PR TITLE
Remove keycloak separate instance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
         touch ~/.config/openstack/secure.yaml
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.2.9
     - name: Terraform Format
       id: fmt
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,22 +76,15 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         ANSIBLE_SECRETS: ${{ secrets.ANSIBLE_SECRETS }}
-        ANSIBLE_SECRETS_KEYCLOAK: ${{ secrets.ANSIBLE_SECRETS_KEYCLOAK }}
       run: |
         cd deploy
         sed -i -e "s/%TOKEN%/${{ steps.generate-token.outputs.token }}/" cloud-init.yaml
         sed -i -e "s/%REF%/${{ github.sha }}/" cloud-init.yaml
         sed -i -e "s/%SHORT_REF%/$(git rev-parse --short HEAD)/" cloud-init.yaml
         sed -i -e "s#%SLACK_WEBHOOK_URL%#$SLACK_WEBHOOK_URL#" cloud-init.yaml
-        cp cloud-init.yaml cloud-init-keycloak.yaml
         ANSIBLE_ENCODED_SECRETS="$(echo "$ANSIBLE_SECRETS" | base64 -w 0)"
         echo "::add-mask::$ANSIBLE_ENCODED_SECRETS"
         sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS/" cloud-init.yaml
-        echo "$ANSIBLE_SECRETS_KEYCLOAK" > secrets.yaml
-        echo "checkin_token_endpoint: https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token" >> secrets.yaml
-        ANSIBLE_ENCODED_SECRETS_KEYCLOAK="$(base64 -w 0 < secrets.yaml)"
-        echo "::add-mask::$ANSIBLE_ENCODED_SECRETS_KEYCLOAK"
-        sed -i -e "s/%ANSIBLE_SECRETS%/$ANSIBLE_ENCODED_SECRETS_KEYCLOAK/" cloud-init-keycloak.yaml
     - name: terraform plan
       id: plan
       if: github.event_name == 'pull_request'

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -8,14 +8,3 @@ resource "openstack_compute_instance_v2" "cloud-info" {
     uuid = var.net_id
   }
 }
-
-resource "openstack_compute_instance_v2" "cloud-info-keycloak" {
-  name            = "cloud-info-keycloak"
-  image_id        = var.image_id
-  flavor_id       = var.flavor_id
-  security_groups = ["default"]
-  user_data       = file("cloud-init-keycloak.yaml")
-  network {
-    uuid = var.net_id
-  }
-}


### PR DESCRIPTION
Just have one instance that will handle everything

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

As we have moved Check-in from MitreID to Keycloak there is no need to keep VMs for both systems in place. This PR gets back to a single VM, reverting the change in #209, and just keeping Keycloak for all sites.

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
