### PR TITLE
Use the Keycloak endpoint

### DIFF
--- a/deploy/playbook.yaml
+++ b/deploy/playbook.yaml
@@ -6,3 +6,4 @@
     tags: ["all", "docker"]
     vars:
       site_config_dir: ../sites/
+      checkin_token_endpoint: https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

#224 removed the keycloak endpoint from the configuration and the ansible role defaulted to the mitreid one. This should bring it back while the role is updated

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
