### PR TITLE
Updated GSI-LCG site configuration

### DIFF
--- a/sites/GSI-LCG2.yaml
+++ b/sites/GSI-LCG2.yaml
@@ -20,3 +20,6 @@ vos:
 - name: vo.envrihub.eu
   auth:
     project_id: 09ea02290dcb4aa0b3bde9b179a45c43
+- name: vo.complex-systems.eu
+  auth:
+    project_id: 260beefcea224be6a278ccb8e89668dd

--- a/sites/GSI-LCG2.yaml
+++ b/sites/GSI-LCG2.yaml
@@ -17,3 +17,6 @@ vos:
 - name: vo.access.egi.eu
   auth:
     project_id: 1392719e6e4c4bf7ba0fce8c0acbbd22
+- name: vo.envrihub.eu
+  auth:
+    project_id: 09ea02290dcb4aa0b3bde9b179a45c43


### PR DESCRIPTION
# Summary

Added vo.envrihub.eu and vo.complex-systems.eu to `sites/GSI-LCG2.yaml`.