### PR TITLE
fix: do not fail silently

### DIFF
--- a/cloud-info/config_generator.py
+++ b/cloud-info/config_generator.py
@@ -84,6 +84,8 @@ def main():
             for field in "client_id", "client_secret", "refresh_token":
                 with open(os.path.join(dir_path, field), "w+") as f:
                     f.write(secrets[s].get(field, None) or "")
+    if not shares:
+        raise Exception("No shares found!")
     config = {"site": {"name": site_name}, "compute": {"shares": shares}}
     print(yaml.dump(config))
 


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

This forces the config generator to exit with an error and therefore not
to be used. Previously, it would just generate an empty configuration that will still be good to run the cloud-info-provider but without any relevant information

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
