### PR TITLE
Remove unsupported VOs from IISAS-FedCloud site

### DIFF
--- a/sites/IISAS-FedCloud-cloud.yaml
+++ b/sites/IISAS-FedCloud-cloud.yaml
@@ -2,18 +2,12 @@
 gocdb: IISAS-FedCloud
 endpoint: https://cloud.ui.savba.sk:5000/v3/
 vos:
-- name: biomed
-  auth:
-    project_id: 74f63e431be04330862fd6d51434dcea
 - name: cloud.egi.eu
   auth:
     project_id: 982ce52d45fe4e33a1c952ab9484c711
 - name: covid19.eosc-synergy.eu
   auth:
     project_id: a22bbffb007745b2934bf308b0a4d186
-- name: cryoem.instruct-eric.eu
-  auth:
-    project_id: af0a1e8165b94365903088e00e34b063
 - name: eosc-synergy.eu
   auth:
     project_id: 51f736d36ce34b9ebdf196cfcabd24ee
@@ -32,9 +26,6 @@ vos:
 - name: vo.access.egi.eu
   auth:
     project_id: 71dc9c3785cc4876bfb1a4bfc681e0f3
-- name: vo.nextgeoss.eu
-  auth:
-    project_id: 6c4aff79522448ac8191e70dcf4a672a
 - name: vo.matrycs.eu
   auth:
     project_id: 6c2453d04ee544868b70684928d96337
@@ -47,9 +38,6 @@ vos:
 - name: vo.e-rihs.eu
   auth:
     project_id: 6eb56eb83eb54aad9c3226cdeb716c8c
-- name: icecube
-  auth:
-    project_id: 6538cd611f9d44f8b07e82fecfd38b6b
 - name: vo.beamide.com
   auth:
     project_id: 5139b731becd4f0b8fbf5fc19b909d58


### PR DESCRIPTION
Remove biomed, cryoem.instruct-eric.eu, vo.nextgeoss.eu and icecube VOs.