### PR TITLE
Remove vo.usegalaxy.eu from GSI-LCG2

### DIFF
--- a/sites/GSI-LCG2.yaml
+++ b/sites/GSI-LCG2.yaml
@@ -23,6 +23,3 @@ vos:
 - name: vo.inteligg.com
   auth:
     project_id: 9fe5330bec51464bad89d368d73b88fc
-- name: vo.usegalaxy.eu
-  auth:
-    project_id: ddbf76b4a9dd4a8293bd8a804eab68f4


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

GSI-LCG2 no longer supports the `vo.usegalaxy.eu` VO.

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
