### PR TITLE
Update ILIFU-UCT.yaml

### DIFF
--- a/sites/ILIFU-UCT.yaml
+++ b/sites/ILIFU-UCT.yaml
@@ -1,5 +1,5 @@
 gocdb: ILIFU-UCT
-endpoint: https://dashboard2.ilifu.ac.za:5000/v3
+endpoint: https://openstack.ilifu.ac.za:5000/v3
 vos:
 - name: ops
   auth:


### PR DESCRIPTION
Ilifu Openstack is now accessible at https://openstack.ilifu.ac.za rather than at https://dashboard2.ilifu.ac.za.  Though the old dashboard2 DNS entry still points to the same IP as openstack.ilifu.ac.za use of the old hostname may result in an invalid redirect error when using OIDC authentication.