### PR TITLE
Fix the issues found in the deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,19 +68,13 @@ jobs:
         run: |
           cd deploy
           terraform init
-      - name: Generate token for getting git repo at VM
-        uses: tibdex/github-app-token@v2
-        id: generate-token
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Adjust cloud-init file
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ANSIBLE_SECRETS: ${{ secrets.ANSIBLE_SECRETS }}
         run: |
           cd deploy
-          sed -i -e "s/%TOKEN%/${{ steps.generate-token.outputs.token }}/" cloud-init.yaml
+          sed -i -e "s/%TOKEN%/${{ secrets.GITHUB_TOKEN }}/" cloud-init.yaml
           sed -i -e "s/%REF%/${{ github.sha }}/" cloud-init.yaml
           sed -i -e "s/%SHORT_REF%/$(git rev-parse --short HEAD)/" cloud-init.yaml
           sed -i -e "s#%SLACK_WEBHOOK_URL%#$SLACK_WEBHOOK_URL#" cloud-init.yaml
@@ -130,22 +124,28 @@ jobs:
         run: |
           cd deploy
           terraform apply -auto-approve -var-file="$EGI_SITE.tfvars"
-          echo "VM_ID=$(terraform output -raw instance-id)" >> "$GITHUB_ENV"
+      - name: Get VM ID
+        id: terraform-vm-id
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          cd deploy
+          terraform output -raw instance-id
       - name: Get the status file from swift
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
-          max_attempts: 10
-          command: |
-            cd deploy
-            openstack --os-cloud backend object save fedcloud-catchall "$VM_ID"
-            # we don't need it around
-            openstack --os-cloud backend object delete fedcloud-catchall "$VM_ID"
+          max_attempts: 20
+          retry_wait_seconds: 40
+          command: >
+            set -x &&
+            pushd deploy &&
+            openstack --os-cloud backend object save fedcloud-catchall "${{ steps.terraform-vm-id.outputs.stdout }}" &&
+            openstack --os-cloud backend object delete fedcloud-catchall "${{ steps.terraform-vm-id.outputs.stdout }}"
       - name: Look for errors
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           cd deploy
-          # show the status
-          cat "$VM_ID"
-          grep -v "error" "$VM_ID"
+          # show the status in the build log
+          cat "${{ steps.terraform-vm-id.outputs.stdout }}"
+          grep -v "error" "${{ steps.terraform-vm-id.outputs.stdout }}"

--- a/deploy/cloud-init.yaml
+++ b/deploy/cloud-init.yaml
@@ -59,7 +59,7 @@ write_files:
 
       cloud-init status --wait -l > "/var/tmp/egi/$VM_ID"
       # try 10 times, otherwise just die
-      retry -t 10 -d 90 openstack --os-cloud backend object create \
+      retry -t 10 -d 90 -- openstack --os-cloud backend object create \
             --name "$VM_ID" fedcloud-catchall "/var/tmp/egi/$VM_ID"
     path: /usr/local/bin/notify.sh
     permissions: '0755'

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -36,7 +36,6 @@ GITHUB_COMMIT_URL="https://api.github.com/repos/EGI-Federation/fedcloud-catchall
 
 # Find out PR we need to update
 ISSUE_NUMBER=$(curl \
-                 -H "Authorization: token $OAUTH_TOKEN" \
                  -H "Accept: application/vnd.github.groot-preview+json" \
                  "$GITHUB_COMMIT_URL" | jq .[0].number)
 


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

#307 did not correctly checked the output of the deployment. Now we correctly get the VM id and wait for the object storage file with the status to be available.

With these changes the deploy action won't succeed if the VM didn't start and finalise the configuration to the very last bit (A failed build may still be correct at the VM!) This avoids situations where the GitHub action was completed without error and the cloud-info-provider was clearly not working, so we can react promptly. 

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**  #307
