### PR TITLE
Add TR-FC1-ULAKBIM to vo.usegalaxy.eu

### DIFF
--- a/sites/TR-FC1-ULAKBIM.yaml
+++ b/sites/TR-FC1-ULAKBIM.yaml
@@ -32,3 +32,6 @@ vos:
 - name: vo.imagine-ai.eu
   auth:
     project_id: 3c1f7074ad974024849cfd01a4b3858d
+- name: vo.usegalaxy.eu
+  auth:
+    project_id: 5eef96ac9de4417aa50395a12d793b48


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

@hbayindir I am adding here the info about `vo.usegalaxy.eu` at `TR-FC1-ULAKBIM`.

I initially requested the mapping of this entitlement:

```yaml
urn:mace:egi.eu:group:vo.usegalaxy.eu:role=member#aai.egi.eu
```

But instead I realised it should be this one:
https://github.com/EGI-Federation/fedcloud-catchall-operations/blob/b852bd6ced9f03d6fbfda4a637753c4d34400cba/vo-mappings.yaml#L91

Could you please update it?

Many thanks!
Sebastian

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
