### PR TITLE
Revisiting ssh-oidc config

### DIFF
--- a/deploy/cloud-info/backend.tf
+++ b/deploy/cloud-info/backend.tf
@@ -1,3 +1,11 @@
+# This is where the info about the deployment is to be stored
+terraform {
+  backend "swift" {
+    container = "terraform"
+    cloud     = "backend"
+  }
+}
+
 # The provider where the deployment is actually performed
 provider "openstack" {
   cloud = "deploy"

--- a/deploy/cloud-info/backend.tf
+++ b/deploy/cloud-info/backend.tf
@@ -1,11 +1,3 @@
-# This is where the info about the deployment is to be stored
-terraform {
-  backend "swift" {
-    container = "terraform"
-    cloud     = "backend"
-  }
-}
-
 # The provider where the deployment is actually performed
 provider "openstack" {
   cloud = "deploy"

--- a/deploy/cloud-info/main.tf
+++ b/deploy/cloud-info/main.tf
@@ -1,8 +1,24 @@
+resource "openstack_networking_secgroup_v2" "motley" {
+  name                 = "motley"
+  description          = "Open ports for motley-cue"
+  delete_default_rules = "true"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "motley-8080" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8080
+  port_range_max    = 8080
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.motley.id
+}
+
 resource "openstack_compute_instance_v2" "cloud-info" {
   name            = "cloud-info"
   image_id        = var.image_id
   flavor_id       = var.flavor_id
-  security_groups = ["default"]
+  security_groups = ["default", "motley"]
   user_data       = file("cloud-init.yaml")
   network {
     uuid = var.net_id

--- a/deploy/cloud-init.yaml
+++ b/deploy/cloud-init.yaml
@@ -13,11 +13,10 @@ users:
 
 packages:
   - git
-  - ansible
   - jq
   - python3-openstackclient
   - python3-pip
-  - python3.10-venv
+  - python3-venv
   - retry
 
 write_files:

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -48,7 +48,7 @@ ansible-galaxy role install -r galaxy-requirements.yaml
 if ansible-playbook -i inventory.yaml \
 	--extra-vars @secrets.yaml \
 	--extra-vars @extra-vars.yaml \
-	--extra-vars ACCESS_TOKEN="$ACCESS_TOKEN" \
+	--extra-vars ACCESS_TOKEN=$ACCESS_TOKEN \
 	--tags "$TAGS" \
 	playbook.yaml >ansible.log 2>&1; then
 	status_summary="success"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -48,7 +48,7 @@ ansible-galaxy role install -r galaxy-requirements.yaml
 if ansible-playbook -i inventory.yaml \
 	--extra-vars @secrets.yaml \
 	--extra-vars @extra-vars.yaml \
-	--extra-vars ACCESS_TOKEN=$ACCESS_TOKEN \
+	--extra-vars ACCESS_TOKEN="$ACCESS_TOKEN" \
 	--tags "$TAGS" \
 	playbook.yaml >ansible.log 2>&1; then
 	status_summary="success"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -35,8 +35,8 @@ CLIENT_ID=$(yq -r '.fedcloudops.client_id' secrets.yaml)
 CLIENT_SECRET=$(yq -r '.fedcloudops.client_secret' secrets.yaml)
 SCOPE="openid%20email%20profile%20voperson_id%20eduperson_entitlement"
 ACCESS_TOKEN=$(curl --request POST "https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token" \
-  --data "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=$SCOPE" \
-  | jq -r ".access_token")
+	--data "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=$SCOPE" |
+	jq -r ".access_token")
 
 # use pip-installed Ansible (apt version is too old)
 pip install ansible

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -30,6 +30,17 @@ image_sync_image: "ghcr.io/egi-federation/fedcloud-image-sync:sha-$SHORT_SHA"
 site_config_dir: "$(readlink -f ../sites)"
 EOF
 
+# get access token for motley-cue
+CLIENT_ID=$(yq -r '.fedcloudops.client_id' secrets.yaml)
+CLIENT_SECRET=$(yq -r '.fedcloudops.client_secret' secrets.yaml)
+SCOPE="openid%20email%20profile%20voperson_id%20eduperson_entitlement"
+ACCESS_TOKEN=$(curl --request POST "https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/token" \
+  --data "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=$SCOPE" \
+  | jq -r ".access_token")
+
+# use pip-installed Ansible (apt version is too old)
+pip install ansible
+
 # install Ansible dependencies
 ansible-galaxy role install -r galaxy-requirements.yaml
 
@@ -37,6 +48,7 @@ ansible-galaxy role install -r galaxy-requirements.yaml
 if ansible-playbook -i inventory.yaml \
 	--extra-vars @secrets.yaml \
 	--extra-vars @extra-vars.yaml \
+	--extra-vars ACCESS_TOKEN=$ACCESS_TOKEN \
 	--tags "$TAGS" \
 	playbook.yaml >ansible.log 2>&1; then
 	status_summary="success"

--- a/deploy/playbook.yaml
+++ b/deploy/playbook.yaml
@@ -7,7 +7,7 @@
         ssh_oidc_other_vos_name: cloud.egi.eu
         ssh_oidc_other_vos_role: auditor
       tags:
-        - never
+        - always
     - role: catchall
       vars:
         site_config_dir: ../sites/


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

We previously tried to grant access via `ssh-oidc` to members of the `cloud.egi.eu` VO with the `auditor` role. See #364, #365, #366, #367, and #368.

However, the ansible configuration of the VM fails after completing the `grycap.motley_cue` role and starting with the `catchall` role in the [playbook](https://github.com/EGI-Federation/fedcloud-catchall-operations/blob/adc040c7081c50ad368f081a7eb746bc5fc4c279/deploy/playbook.yaml) with this error:

```bash
TASK [catchall : Ensure cron is available] *************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?
```

The issue seems to happen with the version of `ansible` installed with `apt` on [Ubuntu 22.04](https://packages.ubuntu.com/source/jammy/ansible). Installing the latest `ansible` version with `pip` seems to solve the issue.

In this PR I am also:
* adding a security group to enable access with `ssh-oidc`
* passing an access token to the `grycap.motley_cue` role with Ansible

Let's see how it goes this time.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
