### PR TITLE
Define image formats for BIFI

### DIFF
--- a/sites/BIFI.yaml
+++ b/sites/BIFI.yaml
@@ -3,6 +3,9 @@ gocdb: BIFI
 endpoint: https://colossus.cesar.unizar.es:5000/v3
 images:
   sync: true
+  formats:
+    - qcow2
+    - raw
 vos:
   - name: ops
     auth:

--- a/sites/BIFI.yaml
+++ b/sites/BIFI.yaml
@@ -2,27 +2,6 @@
 gocdb: BIFI
 endpoint: https://colossus.cesar.unizar.es:5000/v3
 vos:
-  - name: covid19.eosc-synergy.eu
-    auth:
-      project_id: f07679a8d4ac40379b51db4236bc3c27
-  - name: eosc-synergy.eu
-    auth:
-      project_id: 0c1de26753ed4311a6cefff9094ad3e3
-  - name: lagoproject.net
-    auth:
-      project_id: 21a85c6ead0346b08e22709d0422799d
-  - name: o3as.data.kit.edu
-    auth:
-      project_id: 621b1977bb384beab1519713c7e695f0
   - name: ops
     auth:
-      project_id: 6930771153aa4b8d8637222dec8fd949
-  - name: worsica.vo.incd.pt
-    auth:
-      project_id: 46f55a92f3904d509d75525930d8d0eb
-  - name: vo.phiri.eu
-    auth:
-      project_id: 1d64c6e5237b46af8acb44f79b7b5a15
-  - name: vo.bd4nrg.eu
-    auth:
-      project_id: 3e18859848be489a8d741b264049f4a9
+      project_id: 038db3eeca5c4960a443a89b92373cd2

--- a/sites/BIFI.yaml
+++ b/sites/BIFI.yaml
@@ -1,6 +1,8 @@
 ---
 gocdb: BIFI
 endpoint: https://colossus.cesar.unizar.es:5000/v3
+images:
+  sync: true
 vos:
   - name: ops
     auth:


### PR DESCRIPTION
Monitor log evidences that colossus openstack doesn't support monitoring image format:

[...]
Build of instance [...] aborted: Image [...] is unacceptable: Image not in a supported format
[...]

So we can force to use qcow2 or raw image formats...