### PR TITLE
feat: CESNET-MCCG2 add dteam VO project ID

### DIFF
--- a/sites/CESNET-MCCG2.yaml
+++ b/sites/CESNET-MCCG2.yaml
@@ -9,3 +9,6 @@ vos:
   - name: ops
     auth:
       project_id: 396c67a5f5bf4188b601927dbe51f386
+  - name: dteam
+    auth:
+      project_id: 2dcdbe7cc967467d81ea45fe143968e7


### PR DESCRIPTION
# Summary

dteam VO project ID added, part of CESNET-MCCG2 certification.

**Related issue :** N/A
