### PR TITLE
dteam VO is no longer required for EGI cloud sites

### DIFF
--- a/sites/CESNET-MCCG2.yaml
+++ b/sites/CESNET-MCCG2.yaml
@@ -9,9 +9,6 @@ vos:
   - name: ops
     auth:
       project_id: 396c67a5f5bf4188b601927dbe51f386
-  - name: dteam
-    auth:
-      project_id: 2dcdbe7cc967467d81ea45fe143968e7
   - name: envri-vre
     auth:
       project_id: 1561ad2c9e974ae9840d413b4bdea699

--- a/sites/CESNET-MCCG2.yaml
+++ b/sites/CESNET-MCCG2.yaml
@@ -12,3 +12,6 @@ vos:
   - name: envri-vre
     auth:
       project_id: 1561ad2c9e974ae9840d413b4bdea699
+  - name: biomed
+    auth:
+      project_id: 42d7c31f28874fa0b85d23c969134a1d


### PR DESCRIPTION

# Summary

Dropping dteam VO from CESNET-MCCG2 as this VO is no longer needed.