### PR TITLE
Remove fedcloud.egi.eu VO in favor of vo.access.egi.eu VO

### DIFF
--- a/sites/CETA-GRID.yaml
+++ b/sites/CETA-GRID.yaml
@@ -11,9 +11,6 @@ vos:
   - name: eosc-synergy.eu
     auth:
       project_id: 8e0f99db8b7845d38512f0ddce9049e3
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: 8ad2ac56f33540cdbfbd45ad5095d924
   - name: lagoproject.net
     auth:
       project_id: 3afddede673548a99dc5c2e819baf5a8

--- a/sites/CLOUDIFIN.yaml
+++ b/sites/CLOUDIFIN.yaml
@@ -5,9 +5,6 @@ vos:
   - name: dteam
     auth:
       project_id: f726c16f3e2346bf891021c89b4dc58d
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: 245cdfdce0c84227b9b60d247618f635
   - name: ops
     auth:
       project_id: 21440821c8904e5b8ce5ec101a1ca879

--- a/sites/CSTCLOUD-EGI.yaml
+++ b/sites/CSTCLOUD-EGI.yaml
@@ -17,6 +17,3 @@ vos:
   - name: eiscat.se
     auth:
       project_id: be43e5f92b3e49c387a5b00549938770
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: b33f036b6a584c4d844df5a505f53d16

--- a/sites/CYFRONET-CLOUD.yaml
+++ b/sites/CYFRONET-CLOUD.yaml
@@ -8,9 +8,6 @@ vos:
   - name: dteam
     auth:
       project_id: 9b40bb40431c4f4180c280b6675f9bb9
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: 1295728b1ce747fb96c043c6e254ad6f
   - name: ops
     auth:
       project_id: c030e7317150482d920717888e82ce5f

--- a/sites/DESY-CC.yaml
+++ b/sites/DESY-CC.yaml
@@ -2,9 +2,6 @@
 gocdb: DESY-CC
 endpoint: https://ccmi-api.desy.de:5000/v3
 vos:
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: 84ef898d6bdc4d01aaabdf1dda2ca791
   - name: vo.panosc.eu
     auth:
       project_id: ac06d127fc14463c9bd283f08e731eb2

--- a/sites/IN2P3-IRES.yaml
+++ b/sites/IN2P3-IRES.yaml
@@ -14,9 +14,6 @@ vos:
   - name: dteam
     auth:
       project_id: 2490c27604904357b9e50c5e77aaeedf
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: a5eb30bba2c2497b90645fb199e34b39
   - name: lagoproject.net
     auth:
       project_id: bae9cee37c434aaa8548994f070521a3

--- a/sites/INFN-CLOUD-CNAF.yaml
+++ b/sites/INFN-CLOUD-CNAF.yaml
@@ -6,9 +6,6 @@ vos:
   - name: dteam
     auth:
       project_id: a8af02aad2894e9e8b5d4775c9736b8a
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: a8af02aad2894e9e8b5d4775c9736b8a
   - name: fermi-lat.infn.it
     auth:
       project_id: d20b02f7f6254acab37b29a0e74015c2

--- a/sites/NCG-INGRID-PT.yaml
+++ b/sites/NCG-INGRID-PT.yaml
@@ -17,9 +17,6 @@ vos:
   - name: eosc-synergy.eu
     auth:
       project_id: ddf0c468c8af4e0bbb9808bfc0288381
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: bd5a81e1670b48f18af33b05512a9d77
   - name: opencoast.eosc-hub.eu
     auth:
       project_id: b0cea6bd85844b0693ceda70d9f94a09

--- a/sites/TR-FC1-ULAKBIM.yaml
+++ b/sites/TR-FC1-ULAKBIM.yaml
@@ -11,9 +11,6 @@ vos:
   - name: enmr.eu
     auth:
       project_id: 261e58163d204beb8d6ee82cca385771
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: c2ffb5336de9467c8a588038e2c06750
   - name: fusion
     auth:
       project_id: 0606cbf2743c4bbc8680227247f4d616

--- a/sites/UA-BITP.yaml
+++ b/sites/UA-BITP.yaml
@@ -5,9 +5,6 @@ vos:
   - name: dteam
     auth:
       project_id: 1305de6b15384e0c8d77251ab6f703af
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: 8d48556b378549a3a3f02ce933096c1f
   - name: ops
     auth:
       project_id: ea6e7637552d476d8247b5d42a07df7d

--- a/sites/fedcloud.srce.hr.yaml
+++ b/sites/fedcloud.srce.hr.yaml
@@ -5,9 +5,6 @@ vos:
   - name: dteam
     auth:
       project_id: 8fbe7b83bfa7420ea75bbceb761ad079
-  - name: fedcloud.egi.eu
-    auth:
-      project_id: 662f67f51f4c451987e62b17820a2bc5
   - name: ops
     auth:
       project_id: 949f4fe468164de9a8afdf03e70a6fc0

--- a/vo-mappings.yaml
+++ b/vo-mappings.yaml
@@ -21,7 +21,6 @@ vos:
   enmr.eu: "urn:mace:egi.eu:group:enmr.eu:role=vm_operator#aai.egi.eu"
   eosc-synergy.eu: "urn:mace:egi.eu:group:eosc-synergy.eu:role=vm_operator#aai.egi.eu"
   eval.c-scale.eu: "urn:mace:egi.eu:group:eval.c-scale.eu:role=member#aai.egi.eu"
-  fedcloud.egi.eu: "urn:mace:egi.eu:group:fedcloud.egi.eu:vm_operator:role=member#aai.egi.eu"
   fermi-lat.infn.it: "urn:mace:egi.eu:group:fermi-lat.infn.it:role=vm_operator#aai.egi.eu"
   fusion: "urn:mace:egi.eu:group:fusion:role=vm_operator#aai.egi.eu"
   icecube: "urn:mace:egi.eu:group:icecube:role=vm_operator#aai.egi.eu"


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

As agreed internally let's remove `fedcloud.egi.eu` VO in favor of `vo.access.egi.eu` VO

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** https://ggus.eu/index.php?mode=ticket_info&ticket_id=169396
