### PR TITLE
New VOs on site fedcloud.srce.hr

### DIFF
--- a/sites/fedcloud.srce.hr.yaml
+++ b/sites/fedcloud.srce.hr.yaml
@@ -13,3 +13,6 @@ vos:
   - name: vo.epos-eric.eu
     auth:
       project_id: 44a3a5f9c2f44940acc98a8aee3875ba
+  - name: cloud.egi.eu
+    auth:
+      project_id: 258f0bdb2c4c4dba9eb3b96823e20b09

--- a/sites/fedcloud.srce.hr.yaml
+++ b/sites/fedcloud.srce.hr.yaml
@@ -10,3 +10,6 @@ vos:
   - name: ops
     auth:
       project_id: c99c8b38569546008104fbaa12fe3aa9
+  - name: vo.epos-eric.eu
+    auth:
+      project_id: 44a3a5f9c2f44940acc98a8aee3875ba


### PR DESCRIPTION
Project ID's for two new VOs: `cloud.egi.eu` and `vo.epos-eric.eu`