### PR TITLE
Use site name instead of site ID when querying cloud-info-api

### DIFF
--- a/image-sync/image_sync/sync.py
+++ b/image-sync/image_sync/sync.py
@@ -80,7 +80,7 @@ def fetch_site_info_cloud_info():
     for site in r.json():
         try:
             r = httpx.get(
-                os.path.join(CONF.sync.cloud_info_url, f"site/{site['id']}/projects")
+                os.path.join(CONF.sync.cloud_info_url, f"site/{site['name']}/projects")
             )
             r.raise_for_status()
         except httpx.HTTPError as e:


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Change required to work after https://github.com/EGI-Federation/cloud-info-api/pull/31

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** https://github.com/EGI-Federation/cloud-info-api/pull/31
