### PR TITLE
fix: make cloud-info-json work for failing sites

### DIFF
--- a/cloud-info/Dockerfile
+++ b/cloud-info/Dockerfile
@@ -33,7 +33,7 @@ RUN pip install --no-cache-dir .
 RUN python -m venv /cloud-info-json \
     && /cloud-info-json/bin/pip install --no-cache-dir \
          git+https://github.com/EGI-Federation/cloud-info-provider.git@641c3661fe55d14846573f88198f892ba0d03094 \
-    && cat /etc/grid-security/certificates/*.pem >> "$(python -m requests.certs)"
+    && cat /etc/grid-security/certificates/*.pem >> "$(/cloud-info-json/bin/python -m requests.certs)"
 
 # The actual image
 FROM python:3


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
Fix issues found in production:
- Missing CA certificates in the cloud-info-json venv

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** https://github.com/EGI-Federation/cloud-info-api/issues/39
