### PR TITLE
Move to new apt key handling

### DIFF
--- a/caso/Dockerfile
+++ b/caso/Dockerfile
@@ -7,10 +7,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # We do need install recommends for the CAs
 # hadolint ignore=DL3015, DL3008
 RUN apt-get update \
-    && apt-get -qy install --fix-missing --no-install-recommends curl \
-    && curl https://dl.igtf.net/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-4 | apt-key add - \
-    && echo 'deb http://repository.egi.eu/sw/production/cas/1/current egi-igtf core' \
-             > /etc/apt/sources.list.d/cas.list \
+    && apt-get -qy install --fix-missing --no-install-recommends gnupg curl \
+    && curl -s https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-4 \
+	| gpg --dearmor  -o /etc/apt/keyrings/eugridpma.gpg  \
+    && echo "deb [signed-by=/etc/apt/keyrings/eugridpma.gpg] https://repository.egi.eu/sw/production/cas/1/current egi-igtf core" \
+             > /etc/apt/sources.list.d/igtf.list \
     && apt-get update \
     && apt-get -qy install --fix-missing fetch-crl \
     && apt-get -qy install --fix-missing ca-policy-egi-core \

--- a/cloud-info/Dockerfile
+++ b/cloud-info/Dockerfile
@@ -3,9 +3,12 @@ FROM python:3 AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
-RUN curl -s https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-4 \
-	| apt-key add - \
-    && echo "deb https://repository.egi.eu/sw/production/cas/1/current egi-igtf core" > /etc/apt/sources.list.d/igtf.list \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       gnupg2 curl \
+    && curl -s https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-4 \
+	| gpg --dearmor  -o /etc/apt/keyrings/eugridpma.gpg  \
+    && echo "deb [signed-by=/etc/apt/keyrings/eugridpma.gpg] https://repository.egi.eu/sw/production/cas/1/current egi-igtf core" > /etc/apt/sources.list.d/igtf.list \
     && apt-get update \
     && apt-get install -y ca-policy-egi-core \
     && rm -rf /var/lib/apt/lists/*

--- a/image-sync/Dockerfile
+++ b/image-sync/Dockerfile
@@ -27,8 +27,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        gnupg2 qemu-utils curl \
     && curl -s https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-4 \
-	| apt-key add - \
-    && echo "deb https://repository.egi.eu/sw/production/cas/1/current egi-igtf core" > /etc/apt/sources.list.d/igtf.list \
+	| gpg --dearmor  -o /etc/apt/keyrings/eugridpma.gpg  \
+    && echo "deb [signed-by=/etc/apt/keyrings/eugridpma.gpg] https://repository.egi.eu/sw/production/cas/1/current egi-igtf core" > /etc/apt/sources.list.d/igtf.list \
     && apt-get update \
     && apt-get install -y ca-policy-egi-core \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

apt-key is deprecated in the latest python docker images

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
