### PR TITLE
Install cloud-info-provider from pip

### DIFF
--- a/cloud-info/requirements.txt
+++ b/cloud-info/requirements.txt
@@ -1,6 +1,4 @@
-# Cloud info version is 6fbbf1c24bd32c21d5b8de783d7face6c6c5987e
-# 6fbbf1c24bd32c21d5b8de783d7face6c6c5987e includes json glue support and fixes for it
-git+https://github.com/EGI-Federation/cloud-info-provider.git@88c3a14d1e11c1adf9a03c85679cdcc8e3a2ede1
+cloud-info-provider==1.0.0
 python-glanceclient==4.10.0
 python-novaclient==18.11.0
 python-keystoneclient==5.7.0


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
As I finally managed to create releases of the cloud-info-provider, use the package coming from PyPi instead of directly using the git repo.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
