### PR TITLE
Bugfix OpenStack command in GitHub action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,8 +185,8 @@ jobs:
           retry_wait_seconds: 40
           command: >
             pushd "${{ inputs.dir }}" \
-              && openstack --os-cloud backend
-                --os-token "$BACKEND_OS_TOKEN" object save fedcloud-catchall
+              && openstack --os-cloud backend \
+                --os-token "$BACKEND_OS_TOKEN" object save fedcloud-catchall \
                  "${{ steps.terraform-vm-id.outputs.stdout }}" \
               && openstack --os-cloud backend \
                 --os-token "$BACKEND_OS_TOKEN" object delete \


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Fix these errors in Actions

```
Attempt 11
  ~/work/fedcloud-catchall-operations/fedcloud-catchall-operations/deploy/cloud-info ~/work/fedcloud-catchall-operations/fedcloud-catchall-operations
  openstack: '--os-cloud' is not an openstack command. See 'openstack --help'.
  Did you mean one of these?
    console log show
    console url show
  openstack: 'backend' is not an openstack command. See 'openstack --help'.
  Did you mean one of these?
    access rule delete
    access rule list
    access rule show
    access token create
  Warning: Attempt 11 failed. Reason: Timeout of 600000ms hit
```

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
