### PR TITLE
feat: CESNET-MCCG2 now supports vo.greendigit.egi.eu VO

### DIFF
--- a/sites/CESNET-MCCG2.yaml
+++ b/sites/CESNET-MCCG2.yaml
@@ -69,6 +69,6 @@ vos:
   - name: vo.eosc-data-commons.eu
     auth:
       project_id: 5c338f6614704093991f9b6e17f54f90
-  - name:  vo.greendigit.egi.eu
+  - name: vo.greendigit.egi.eu
     auth:
       project_id: da9146405f5e493c8f374b98c1224f4c

--- a/sites/CESNET-MCCG2.yaml
+++ b/sites/CESNET-MCCG2.yaml
@@ -69,3 +69,6 @@ vos:
   - name: vo.eosc-data-commons.eu
     auth:
       project_id: 5c338f6614704093991f9b6e17f54f90
+  - name:  vo.greendigit.egi.eu
+    auth:
+      project_id: da9146405f5e493c8f374b98c1224f4c


### PR DESCRIPTION
# Summary

CESNET-MCCG2 now supports vo.greendigit.egi.eu VO
